### PR TITLE
Store and process bot events for unknown users in AttendanceEvent

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -4,6 +4,7 @@ import type { JWT } from 'next-auth/jwt';
 import DiscordProvider from 'next-auth/providers/discord';
 import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
+import { processPendingEventsForUser } from '@/lib/pending-events';
 
 interface DiscordProfile {
   id: string;
@@ -99,7 +100,6 @@ export const authOptions: AuthOptions = {
           }
         } else {
           // Create new user and link the account
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           const newUser = await prisma.user.create({
             data: {
               username,
@@ -113,6 +113,9 @@ export const authOptions: AuthOptions = {
               },
             },
           });
+
+          // Process any pending attendance events for this Discord user
+          await processPendingEventsForUser(undefined, providerUserId, newUser.id);
         }
       } else if (provider === 'discord') {
         const cookieStore = await cookies();

--- a/app/api/auth/steam-callback/route.ts
+++ b/app/api/auth/steam-callback/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { processPendingEventsForUser } from '@/lib/pending-events';
 
 export async function GET(request: NextRequest) {
   const baseUrl = process.env.NEXTAUTH_URL || 'http://localhost:3000';
@@ -102,7 +103,8 @@ export async function GET(request: NextRequest) {
         },
       });
       
-      authAccount = await prisma.authAccount.findUnique({
+      // Get the newly created user to process any pending attendance events
+      const newAuthAccount = await prisma.authAccount.findUnique({
         where: {
           provider_providerUserId: {
             provider: 'steam',
@@ -111,6 +113,13 @@ export async function GET(request: NextRequest) {
         },
         include: { user: true },
       });
+
+      // Process any pending events for this Steam ID
+      if (newAuthAccount?.user) {
+        await processPendingEventsForUser(steamId, null, newAuthAccount.user.id);
+      }
+      
+      authAccount = newAuthAccount;
     }
     
     if (!authAccount) {

--- a/app/api/bot/attendance/compile/route.ts
+++ b/app/api/bot/attendance/compile/route.ts
@@ -82,9 +82,12 @@ export async function POST(request: NextRequest) {
       orderBy: { eventTime: 'asc' },
     });
 
-    // Group events by user
+    // Group events by user (only include events with a userId)
     const userEvents: Record<number, { joins: Date[]; leaves: Date[] }> = {};
     for (const event of events) {
+      // Skip events that haven't been matched to a user yet (processed = false, userId = null)
+      if (!event.userId) continue;
+      
       if (!userEvents[event.userId]) {
         userEvents[event.userId] = { joins: [], leaves: [] };
       }

--- a/app/api/bot/events/route.ts
+++ b/app/api/bot/events/route.ts
@@ -6,6 +6,32 @@ function validateBotToken(request: NextRequest): Promise<boolean> {
   return validateBotTokenLegacy(request);
 }
 
+// Helper to handle duplicate events: check last event and only store if different
+async function shouldStoreEvent(steamId: string | null | undefined, discordId: string | null | undefined, isJoin: boolean, eventTime: Date): Promise<boolean> {
+  if (!steamId && !discordId) return true;
+
+  // Find the last UNPROCESSED event for this user identifier
+  const lastEvent = await prisma.attendanceEvent.findFirst({
+    where: {
+      OR: [
+        steamId ? { steamId, processed: false } : {},
+        discordId ? { discordId, processed: false } : {},
+      ],
+    },
+    orderBy: { eventTime: 'desc' },
+  });
+
+  // If no previous event, or if the event type is different, store it
+  if (!lastEvent) return true;
+  
+  // If same event type consecutively (join-join or leave-leave), skip the duplicate
+  if (lastEvent.isJoin === isJoin) {
+    return false;
+  }
+
+  return true;
+}
+
 export async function POST(request: NextRequest) {
   try {
     if (!(await validateBotToken(request))) {
@@ -46,6 +72,21 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Check for duplicate consecutive events (join-join, leave-leave)
+    const storeEvent = await shouldStoreEvent(steamId, discordUserId, isJoin, eventTime);
+    if (!storeEvent) {
+      return NextResponse.json({
+        success: true,
+        message: 'Duplicate consecutive event skipped',
+        steamId,
+        discordId: discordUserId,
+        isJoin,
+        eventTime: eventTime.toISOString(),
+        processed: true,
+        duplicate: true,
+      });
+    }
+
     // Look up user by Steam ID or Discord ID
     let user = null;
     if (steamId) {
@@ -64,47 +105,33 @@ export async function POST(request: NextRequest) {
       if (discordAccount) user = discordAccount.user;
     }
 
-    if (user) {
-      // User exists - store as normal attendance event
-      const event = await prisma.attendanceEvent.create({
-        data: {
-          userId: user.id,
-          isJoin,
-          eventTime,
-        },
-      });
-
-      return NextResponse.json({
-        success: true,
-        eventId: event.id,
-        userId: user.id,
-        username: user.username,
-        isJoin,
-        eventTime: event.eventTime.toISOString(),
-        processed: true,
-      });
-    } else {
-      // User doesn't exist yet - store as pending event to be processed later
-      const pendingEvent = await prisma.pendingAttendanceEvent.create({
-        data: {
-          steamId,
-          discordId: discordUserId,
-          isJoin,
-          eventTime,
-        },
-      });
-
-      return NextResponse.json({
-        success: true,
-        pendingEventId: pendingEvent.id,
+    // Always store the event in AttendanceEvent
+    // If user exists, link it and mark as processed; otherwise store with steamId/discordId
+    const event = await prisma.attendanceEvent.create({
+      data: {
+        userId: user?.id,
         steamId,
-        discordUserId,
+        discordId: discordUserId,
         isJoin,
-        eventTime: pendingEvent.eventTime.toISOString(),
-        processed: false,
-        message: 'Event stored as pending - will be processed when user is created',
-      });
-    }
+        eventTime,
+        processed: user !== null, // true if user found, false if pending
+      },
+    });
+
+    return NextResponse.json({
+      success: true,
+      eventId: event.id,
+      userId: user?.id,
+      username: user?.username,
+      steamId,
+      discordId: discordUserId,
+      isJoin,
+      eventTime: event.eventTime.toISOString(),
+      processed: event.processed,
+      message: user 
+        ? 'Event recorded and processed'
+        : 'Event stored - will be matched to user when account is created',
+    });
   } catch (error) {
     console.error('Bot events error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/app/api/bot/events/route.ts
+++ b/app/api/bot/events/route.ts
@@ -37,6 +37,15 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Parse timestamp first
+    const eventTime = new Date(timestamp);
+    if (isNaN(eventTime.getTime())) {
+      return NextResponse.json(
+        { error: 'Invalid timestamp format. Use ISO 8601 (e.g., 2024-01-15T12:00:00Z)' },
+        { status: 400 }
+      );
+    }
+
     // Look up user by Steam ID or Discord ID
     let user = null;
     if (steamId) {
@@ -55,39 +64,47 @@ export async function POST(request: NextRequest) {
       if (discordAccount) user = discordAccount.user;
     }
 
-    if (!user) {
-      return NextResponse.json(
-        { error: 'User not found', steamId, discordUserId },
-        { status: 404 }
-      );
-    }
+    if (user) {
+      // User exists - store as normal attendance event
+      const event = await prisma.attendanceEvent.create({
+        data: {
+          userId: user.id,
+          isJoin,
+          eventTime,
+        },
+      });
 
-    // Parse timestamp
-    const eventTime = new Date(timestamp);
-    if (isNaN(eventTime.getTime())) {
-      return NextResponse.json(
-        { error: 'Invalid timestamp format. Use ISO 8601 (e.g., 2024-01-15T12:00:00Z)' },
-        { status: 400 }
-      );
-    }
-
-    // Store the raw event
-    const event = await prisma.attendanceEvent.create({
-      data: {
+      return NextResponse.json({
+        success: true,
+        eventId: event.id,
         userId: user.id,
+        username: user.username,
         isJoin,
-        eventTime,
-      },
-    });
+        eventTime: event.eventTime.toISOString(),
+        processed: true,
+      });
+    } else {
+      // User doesn't exist yet - store as pending event to be processed later
+      const pendingEvent = await prisma.pendingAttendanceEvent.create({
+        data: {
+          steamId,
+          discordId: discordUserId,
+          isJoin,
+          eventTime,
+        },
+      });
 
-    return NextResponse.json({
-      success: true,
-      eventId: event.id,
-      userId: user.id,
-      username: user.username,
-      isJoin,
-      eventTime: event.eventTime.toISOString(),
-    });
+      return NextResponse.json({
+        success: true,
+        pendingEventId: pendingEvent.id,
+        steamId,
+        discordUserId,
+        isJoin,
+        eventTime: pendingEvent.eventTime.toISOString(),
+        processed: false,
+        message: 'Event stored as pending - will be processed when user is created',
+      });
+    }
   } catch (error) {
     console.error('Bot events error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/lib/pending-events.ts
+++ b/lib/pending-events.ts
@@ -1,10 +1,13 @@
 import { prisma } from './prisma';
 
 /**
- * Processes pending attendance events for a newly created user
- * Looks up pending events by Steam ID or Discord ID and converts them to regular attendance events
- * @param steamId - Optional Steam ID to match pending events
- * @param discordId - Optional Discord ID to match pending events
+ * Processes unprocessed attendance events for a newly created user
+ * Looks up AttendanceEvent records with matching steamId or discordId that have processed=false
+ * and links them to the user, then marks them as processed.
+ * Also handles duplicate events (join-join, leave-leave) by only keeping the first.
+ * 
+ * @param steamId - Optional Steam ID to match unprocessed events
+ * @param discordId - Optional Discord ID to match unprocessed events
  * @param userId - The new user's ID to link events to
  */
 export async function processPendingEventsForUser(
@@ -17,51 +20,58 @@ export async function processPendingEventsForUser(
   }
 
   try {
-    // Find pending events matching either steamId or discordId
-    const pendingEvents = await prisma.pendingAttendanceEvent.findMany({
+    // Find unprocessed events matching either steamId or discordId
+    const unprocessedEvents = await prisma.attendanceEvent.findMany({
       where: {
         OR: [
-          steamId ? { steamId } : {},
-          discordId ? { discordId } : {},
+          steamId ? { steamId, processed: false } : {},
+          discordId ? { discordId, processed: false } : {},
         ],
-        processedAt: null, // Only process unprocessed events
       },
       orderBy: { eventTime: 'asc' },
     });
 
-    if (pendingEvents.length === 0) {
+    if (unprocessedEvents.length === 0) {
       return { processedCount: 0 };
     }
 
-    // Convert pending events to regular attendance events
-    const now = new Date();
-    const results = await Promise.allSettled(
-      pendingEvents.map(async (pendingEvent) => {
-        try {
-          await prisma.attendanceEvent.create({
-            data: {
+    let processedCount = 0;
+    let lastProcessedEventType: boolean | null = null;
+
+    // Process events in order and handle duplicates
+    for (const event of unprocessedEvents) {
+      try {
+        // Check if this would create a duplicate consecutive event
+        // Skip if same type as last processed event (join-join or leave-leave)
+        if (lastProcessedEventType === event.isJoin) {
+          // Mark as processed but don't count it as a new event
+          await prisma.attendanceEvent.update({
+            where: { id: event.id },
+            data: { 
               userId,
-              isJoin: pendingEvent.isJoin,
-              eventTime: pendingEvent.eventTime,
+              processed: true,
             },
           });
-
-          // Mark as processed
-          await prisma.pendingAttendanceEvent.update({
-            where: { id: pendingEvent.id },
-            data: { processedAt: now },
-          });
-
-          return { success: true };
-        } catch {
-          return { success: false };
+          continue;
         }
-      })
-    );
 
-    const successful = results.filter((r) => r.status === 'fulfilled' && r.value.success).length;
-    
-    return { processedCount: successful };
+        // Link event to user and mark as processed
+        await prisma.attendanceEvent.update({
+          where: { id: event.id },
+          data: { 
+            userId,
+            processed: true,
+          },
+        });
+        
+        lastProcessedEventType = event.isJoin;
+        processedCount++;
+      } catch (error) {
+        console.error(`Error processing pending event ${event.id}:`, error);
+      }
+    }
+
+    return { processedCount };
   } catch (error) {
     console.error('Error processing pending events:', error);
     return { processedCount: 0 };
@@ -69,9 +79,9 @@ export async function processPendingEventsForUser(
 }
 
 /**
- * Get count of unprocessed pending events for a specific Steam or Discord ID
+ * Get count of unprocessed attendance events for a specific Steam or Discord ID
  */
-export async function getPendingEventCount(
+export async function getUnprocessedEventCount(
   steamId: string | null | undefined,
   discordId: string | null | undefined
 ): Promise<number> {
@@ -79,13 +89,12 @@ export async function getPendingEventCount(
     return 0;
   }
 
-  const count = await prisma.pendingAttendanceEvent.count({
+  const count = await prisma.attendanceEvent.count({
     where: {
       OR: [
-        steamId ? { steamId } : {},
-        discordId ? { discordId } : {},
+        steamId ? { steamId, processed: false } : {},
+        discordId ? { discordId, processed: false } : {},
       ],
-      processedAt: null,
     },
   });
 
@@ -93,33 +102,39 @@ export async function getPendingEventCount(
 }
 
 /**
- * Process pending events for all users (can be run as a background job)
+ * Process all unprocessed attendance events (can be run as a background job)
+ * This matches unprocessed events to users based on steamId or discordId
  */
-export async function processAllPendingEvents(): Promise<{ totalProcessed: number }> {
+export async function processAllUnprocessedEvents(): Promise<{ totalProcessed: number }> {
   try {
-    const pendingEvents = await prisma.pendingAttendanceEvent.findMany({
-      where: { processedAt: null },
-      orderBy: { createdAt: 'asc' },
+    const unprocessedEvents = await prisma.attendanceEvent.findMany({
+      where: { 
+        processed: false,
+        OR: [
+          { steamId: { not: null } },
+          { discordId: { not: null } },
+        ],
+      },
+      orderBy: { eventTime: 'asc' },
     });
 
-    if (pendingEvents.length === 0) {
+    if (unprocessedEvents.length === 0) {
       return { totalProcessed: 0 };
     }
 
-    const now = new Date();
     let processedCount = 0;
 
-    for (const pendingEvent of pendingEvents) {
+    for (const event of unprocessedEvents) {
       try {
         // Try to find user by steamId or discordId
         let user = null;
         
-        if (pendingEvent.steamId) {
+        if (event.steamId) {
           const steamAccount = await prisma.authAccount.findUnique({
             where: {
               provider_providerUserId: {
                 provider: 'steam',
-                providerUserId: pendingEvent.steamId,
+                providerUserId: event.steamId,
               },
             },
             include: { user: true },
@@ -127,12 +142,12 @@ export async function processAllPendingEvents(): Promise<{ totalProcessed: numbe
           if (steamAccount) user = steamAccount.user;
         }
 
-        if (!user && pendingEvent.discordId) {
+        if (!user && event.discordId) {
           const discordAccount = await prisma.authAccount.findUnique({
             where: {
               provider_providerUserId: {
                 provider: 'discord',
-                providerUserId: pendingEvent.discordId,
+                providerUserId: event.discordId,
               },
             },
             include: { user: true },
@@ -141,32 +156,45 @@ export async function processAllPendingEvents(): Promise<{ totalProcessed: numbe
         }
 
         if (user) {
-          // Create attendance event for this user
-          await prisma.attendanceEvent.create({
-            data: {
+          // Check for duplicate consecutive events for this user
+          const lastEvent = await prisma.attendanceEvent.findFirst({
+            where: {
               userId: user.id,
-              isJoin: pendingEvent.isJoin,
-              eventTime: pendingEvent.eventTime,
+              processed: true,
             },
+            orderBy: { eventTime: 'desc' },
           });
 
-          // Mark as processed
-          await prisma.pendingAttendanceEvent.update({
-            where: { id: pendingEvent.id },
-            data: { processedAt: now },
-          });
-
-          processedCount++;
+          // Only link if not a duplicate consecutive event
+          if (!lastEvent || lastEvent.isJoin !== event.isJoin) {
+            await prisma.attendanceEvent.update({
+              where: { id: event.id },
+              data: { 
+                userId: user.id,
+                processed: true,
+              },
+            });
+            processedCount++;
+          } else {
+            // Mark as processed but it's a duplicate
+            await prisma.attendanceEvent.update({
+              where: { id: event.id },
+              data: { 
+                userId: user.id,
+                processed: true,
+              },
+            });
+          }
         }
         // If user still doesn't exist, leave it unprocessed for later
       } catch (error) {
-        console.error(`Error processing pending event ${pendingEvent.id}:`, error);
+        console.error(`Error processing unprocessed event ${event.id}:`, error);
       }
     }
 
     return { totalProcessed: processedCount };
   } catch (error) {
-    console.error('Error processing all pending events:', error);
+    console.error('Error processing all unprocessed events:', error);
     return { totalProcessed: 0 };
   }
 }

--- a/lib/pending-events.ts
+++ b/lib/pending-events.ts
@@ -1,0 +1,172 @@
+import { prisma } from './prisma';
+
+/**
+ * Processes pending attendance events for a newly created user
+ * Looks up pending events by Steam ID or Discord ID and converts them to regular attendance events
+ * @param steamId - Optional Steam ID to match pending events
+ * @param discordId - Optional Discord ID to match pending events
+ * @param userId - The new user's ID to link events to
+ */
+export async function processPendingEventsForUser(
+  steamId: string | null | undefined,
+  discordId: string | null | undefined,
+  userId: number
+): Promise<{ processedCount: number }> {
+  if (!steamId && !discordId) {
+    return { processedCount: 0 };
+  }
+
+  try {
+    // Find pending events matching either steamId or discordId
+    const pendingEvents = await prisma.pendingAttendanceEvent.findMany({
+      where: {
+        OR: [
+          steamId ? { steamId } : {},
+          discordId ? { discordId } : {},
+        ],
+        processedAt: null, // Only process unprocessed events
+      },
+      orderBy: { eventTime: 'asc' },
+    });
+
+    if (pendingEvents.length === 0) {
+      return { processedCount: 0 };
+    }
+
+    // Convert pending events to regular attendance events
+    const now = new Date();
+    const results = await Promise.allSettled(
+      pendingEvents.map(async (pendingEvent) => {
+        try {
+          await prisma.attendanceEvent.create({
+            data: {
+              userId,
+              isJoin: pendingEvent.isJoin,
+              eventTime: pendingEvent.eventTime,
+            },
+          });
+
+          // Mark as processed
+          await prisma.pendingAttendanceEvent.update({
+            where: { id: pendingEvent.id },
+            data: { processedAt: now },
+          });
+
+          return { success: true };
+        } catch {
+          return { success: false };
+        }
+      })
+    );
+
+    const successful = results.filter((r) => r.status === 'fulfilled' && r.value.success).length;
+    
+    return { processedCount: successful };
+  } catch (error) {
+    console.error('Error processing pending events:', error);
+    return { processedCount: 0 };
+  }
+}
+
+/**
+ * Get count of unprocessed pending events for a specific Steam or Discord ID
+ */
+export async function getPendingEventCount(
+  steamId: string | null | undefined,
+  discordId: string | null | undefined
+): Promise<number> {
+  if (!steamId && !discordId) {
+    return 0;
+  }
+
+  const count = await prisma.pendingAttendanceEvent.count({
+    where: {
+      OR: [
+        steamId ? { steamId } : {},
+        discordId ? { discordId } : {},
+      ],
+      processedAt: null,
+    },
+  });
+
+  return count;
+}
+
+/**
+ * Process pending events for all users (can be run as a background job)
+ */
+export async function processAllPendingEvents(): Promise<{ totalProcessed: number }> {
+  try {
+    const pendingEvents = await prisma.pendingAttendanceEvent.findMany({
+      where: { processedAt: null },
+      orderBy: { createdAt: 'asc' },
+    });
+
+    if (pendingEvents.length === 0) {
+      return { totalProcessed: 0 };
+    }
+
+    const now = new Date();
+    let processedCount = 0;
+
+    for (const pendingEvent of pendingEvents) {
+      try {
+        // Try to find user by steamId or discordId
+        let user = null;
+        
+        if (pendingEvent.steamId) {
+          const steamAccount = await prisma.authAccount.findUnique({
+            where: {
+              provider_providerUserId: {
+                provider: 'steam',
+                providerUserId: pendingEvent.steamId,
+              },
+            },
+            include: { user: true },
+          });
+          if (steamAccount) user = steamAccount.user;
+        }
+
+        if (!user && pendingEvent.discordId) {
+          const discordAccount = await prisma.authAccount.findUnique({
+            where: {
+              provider_providerUserId: {
+                provider: 'discord',
+                providerUserId: pendingEvent.discordId,
+              },
+            },
+            include: { user: true },
+          });
+          if (discordAccount) user = discordAccount.user;
+        }
+
+        if (user) {
+          // Create attendance event for this user
+          await prisma.attendanceEvent.create({
+            data: {
+              userId: user.id,
+              isJoin: pendingEvent.isJoin,
+              eventTime: pendingEvent.eventTime,
+            },
+          });
+
+          // Mark as processed
+          await prisma.pendingAttendanceEvent.update({
+            where: { id: pendingEvent.id },
+            data: { processedAt: now },
+          });
+
+          processedCount++;
+        }
+        // If user still doesn't exist, leave it unprocessed for later
+      } catch (error) {
+        console.error(`Error processing pending event ${pendingEvent.id}:`, error);
+      }
+    }
+
+    return { totalProcessed: processedCount };
+  } catch (error) {
+    console.error('Error processing all pending events:', error);
+    return { totalProcessed: 0 };
+  }
+}

--- a/prisma/migrations/20260630020809_add_pending_attendance_events/migration.sql
+++ b/prisma/migrations/20260630020809_add_pending_attendance_events/migration.sql
@@ -1,0 +1,24 @@
+-- CreateTable
+CREATE TABLE "PendingAttendanceEvent" (
+    "id" SERIAL NOT NULL,
+    "steamId" TEXT,
+    "discordId" TEXT,
+    "isJoin" BOOLEAN NOT NULL,
+    "eventTime" TIMESTAMP(3) NOT NULL,
+    "processedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PendingAttendanceEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "PendingAttendanceEvent_steamId_idx" ON "PendingAttendanceEvent"("steamId");
+
+-- CreateIndex
+CREATE INDEX "PendingAttendanceEvent_discordId_idx" ON "PendingAttendanceEvent"("discordId");
+
+-- CreateIndex
+CREATE INDEX "PendingAttendanceEvent_isJoin_idx" ON "PendingAttendanceEvent"("isJoin");
+
+-- CreateIndex
+CREATE INDEX "PendingAttendanceEvent_processedAt_idx" ON "PendingAttendanceEvent"("processedAt");

--- a/prisma/migrations/20260630021122_update_attendance_event_with_pending_support/migration.sql
+++ b/prisma/migrations/20260630021122_update_attendance_event_with_pending_support/migration.sql
@@ -1,0 +1,29 @@
+/*
+  Warnings:
+
+  - You are about to drop the `PendingAttendanceEvent` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "AttendanceEvent" DROP CONSTRAINT "AttendanceEvent_userId_fkey";
+
+-- AlterTable
+ALTER TABLE "AttendanceEvent" ADD COLUMN     "discordId" TEXT,
+ADD COLUMN     "processed" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "steamId" TEXT,
+ALTER COLUMN "userId" DROP NOT NULL;
+
+-- DropTable
+DROP TABLE "PendingAttendanceEvent";
+
+-- CreateIndex
+CREATE INDEX "AttendanceEvent_steamId_idx" ON "AttendanceEvent"("steamId");
+
+-- CreateIndex
+CREATE INDEX "AttendanceEvent_discordId_idx" ON "AttendanceEvent"("discordId");
+
+-- CreateIndex
+CREATE INDEX "AttendanceEvent_processed_idx" ON "AttendanceEvent"("processed");
+
+-- AddForeignKey
+ALTER TABLE "AttendanceEvent" ADD CONSTRAINT "AttendanceEvent_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -716,3 +716,19 @@ model BotToken {
   @@index([token])
   @@index([isActive])
 }
+
+model PendingAttendanceEvent {
+  id           Int      @id @default(autoincrement())
+  steamId      String?  // Steam ID if available
+  discordId    String?  // Discord ID if available
+  isJoin      Boolean  // true = join/check-in, false = leave/check-out
+  eventTime    DateTime // When the event occurred
+  processedAt DateTime? // When the event was processed (linked to a user)
+  createdAt    DateTime @default(now())
+
+  // Indexes for efficient lookups
+  @@index([steamId])
+  @@index([discordId])
+  @@index([isJoin])
+  @@index([processedAt])
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -386,14 +386,20 @@ model AttendanceLog {
 
 // Raw attendance events from bot - ORBAT-agnostic
 model AttendanceEvent {
-  id        Int      @id @default(autoincrement())
-  user      User     @relation(fields: [userId], references: [id])
-  userId    Int
-  isJoin   Boolean  // true = check-in/join, false = check-out/leave
-  eventTime DateTime
+  id           Int      @id @default(autoincrement())
+  user         User?    @relation(fields: [userId], references: [id])
+  userId       Int?
+  steamId      String?  // Original Steam ID for events before user was created
+  discordId    String?  // Original Discord ID for events before user was created
+  isJoin      Boolean  // true = check-in/join, false = check-out/leave
+  eventTime    DateTime
+  processed    Boolean  @default(false) // true = event was matched to user, false = pending
 
   @@index([userId])
+  @@index([steamId])
+  @@index([discordId])
   @@index([eventTime])
+  @@index([processed])
 }
 
 model OrbatTemplate {
@@ -717,18 +723,4 @@ model BotToken {
   @@index([isActive])
 }
 
-model PendingAttendanceEvent {
-  id           Int      @id @default(autoincrement())
-  steamId      String?  // Steam ID if available
-  discordId    String?  // Discord ID if available
-  isJoin      Boolean  // true = join/check-in, false = leave/check-out
-  eventTime    DateTime // When the event occurred
-  processedAt DateTime? // When the event was processed (linked to a user)
-  createdAt    DateTime @default(now())
 
-  // Indexes for efficient lookups
-  @@index([steamId])
-  @@index([discordId])
-  @@index([isJoin])
-  @@index([processedAt])
-}


### PR DESCRIPTION
This pull request implements a robust system for handling attendance events from bots when users may not yet exist in the database. It introduces a "pending events" flow, allowing attendance events to be stored with just a Steam or Discord ID, and then automatically linked to user accounts once they are created. This ensures no attendance data is lost if users sign up after their events are logged. The system also prevents duplicate consecutive events (e.g., join-join) and provides utilities for processing and reconciling pending events.

**Pending attendance event handling and reconciliation:**

* Added the `processPendingEventsForUser`, `getUnprocessedEventCount`, and `processAllUnprocessedEvents` utilities in `lib/pending-events.ts` to process and link unprocessed attendance events to users when they are created, and to deduplicate consecutive events.
* Updated authentication flows in `app/api/auth/[...nextauth]/route.ts` and `app/api/auth/steam-callback/route.ts` to call `processPendingEventsForUser` after new user creation, ensuring any pending events are immediately processed. ([app/api/auth/[...nextauth]/route.tsR7](diffhunk://#diff-118b33d86580f1b0da08a4a304657c7f767c63d1238634628ba80a1486575e78R7), [app/api/auth/[...nextauth]/route.tsR116-R118](diffhunk://#diff-118b33d86580f1b0da08a4a304657c7f767c63d1238634628ba80a1486575e78R116-R118), [[1]](diffhunk://#diff-98e302068601456811a08ac38ba1e25c2376794d1595020138306ebb9913dd88R5) [[2]](diffhunk://#diff-98e302068601456811a08ac38ba1e25c2376794d1595020138306ebb9913dd88L105-R107) [[3]](diffhunk://#diff-98e302068601456811a08ac38ba1e25c2376794d1595020138306ebb9913dd88R116-R122)

**API and event processing improvements:**

* Modified the bot events API (`app/api/bot/events/route.ts`) to always store attendance events, even if the user does not exist yet, and to mark them as processed once matched. Added logic to prevent storing duplicate consecutive events. [[1]](diffhunk://#diff-1761336581f12b707326808d6b1045c27138a2bffc9b2c0d494a9d384acf2cedR9-R34) [[2]](diffhunk://#diff-1761336581f12b707326808d6b1045c27138a2bffc9b2c0d494a9d384acf2cedR66-R89) [[3]](diffhunk://#diff-1761336581f12b707326808d6b1045c27138a2bffc9b2c0d494a9d384acf2cedL58-R133)
* Updated the attendance compilation API (`app/api/bot/attendance/compile/route.ts`) to only include events that have been matched to a user, skipping pending events.

**Database schema and migration changes:**

* Updated the `AttendanceEvent` model in `prisma/schema.prisma` to support optional `userId`, `steamId`, `discordId`, and a `processed` boolean flag, with appropriate indexes for efficient querying.
* Added and then removed a temporary `PendingAttendanceEvent` table via migrations, settling on the enhanced `AttendanceEvent` schema with support for pending events. [[1]](diffhunk://#diff-9e947b7a4ca70d06eba34711693b8cd1deeac581c4423676dc8ff44ae968a1ddR1-R24) [[2]](diffhunk://#diff-c1af6efcac7f0a2ab1212914d0013021d0c07bc57f800e0b0c44fad47b13f786R1-R29)

These changes together ensure that attendance events are reliably captured and reconciled, regardless of user sign-up timing, and that the system remains resilient to duplicate data and missing user records.