### PR TITLE
fix: convert attendance note timestamps to ISO format

### DIFF
--- a/app/admin/orbats/[id]/page.tsx
+++ b/app/admin/orbats/[id]/page.tsx
@@ -135,7 +135,11 @@ export default async function AdminOrbatPage({ params }: AdminOrbatPageProps) {
       })),
     })),
     frequencies: orbat.frequencies,
-    attendanceNotes: orbat.attendanceNotes,
+    attendanceNotes: orbat.attendanceNotes.map((note) => ({
+      ...note,
+      createdAt: note.createdAt.toISOString(),
+      updatedAt: note.updatedAt.toISOString(),
+    })),
     tempFrequencies: orbat.tempFrequencies,
   };
 

--- a/app/orbats/[id]/page.tsx
+++ b/app/orbats/[id]/page.tsx
@@ -187,7 +187,11 @@ export default async function OrbatPage({ params }: OrbatPageProps) {
       }),
     })),
     frequencies: orbat.frequencies,
-    attendanceNotes: orbat.attendanceNotes,
+    attendanceNotes: orbat.attendanceNotes.map((note) => ({
+      ...note,
+      createdAt: note.createdAt.toISOString(),
+      updatedAt: note.updatedAt.toISOString(),
+    })),
     tempFrequencies: orbat.tempFrequencies,
   };
 


### PR DESCRIPTION
This pull request updates the serialization of the `attendanceNotes` field in the `AdminOrbatPage` component to ensure date fields are properly formatted as ISO strings before being sent to the client.

Data serialization improvements:

* Modified the mapping of `attendanceNotes` to convert the `createdAt` and `updatedAt` fields to ISO string format, which ensures consistent and correct date handling on the client side. ([app/admin/orbats/[id]/page.tsxL138-R142](diffhunk://#diff-638d0f7bc89afe5cf58cb9245daecb2ea1dfd1738b95be4e6c16b4cb4a3d1e63L138-R142))