### PR TITLE
feat: add account merge functionality with user selection

### DIFF
--- a/app/admin/users/[id]/UserDetailClient.tsx
+++ b/app/admin/users/[id]/UserDetailClient.tsx
@@ -80,10 +80,18 @@ type AttendanceMetrics = {
   recent: AttendanceEntry[];
 };
 
+type MergeCandidate = {
+  id: number;
+  username: string | null;
+  email: string | null;
+  providers: string[];
+};
+
 type UserDetailClientProps = {
   user: UserDetailData;
   attendance: AttendanceMetrics;
   permissions: UserPermission[];
+  mergeCandidates: MergeCandidate[];
   availableTrainings: AvailableTraining[];
   canViewTrainings: boolean;
   canAssignTrainings: boolean;
@@ -102,6 +110,7 @@ export default function UserDetailClient({
   user,
   attendance,
   permissions,
+  mergeCandidates,
   availableTrainings,
   canViewTrainings,
   canAssignTrainings,
@@ -136,6 +145,8 @@ export default function UserDetailClient({
   const [isRemovingTrainingById, setIsRemovingTrainingById] = useState<Record<number, boolean>>({});
   const [selectedTrainingId, setSelectedTrainingId] = useState<number>(availableTrainings[0]?.id ?? 0);
   const [trainingNotes, setTrainingNotes] = useState('');
+  const [selectedMergeSourceId, setSelectedMergeSourceId] = useState<number>(mergeCandidates[0]?.id ?? 0);
+  const [isMergingAccount, setIsMergingAccount] = useState(false);
 
   const groupedPermissions = useMemo(() => {
     const groupMap = new Map<string, UserPermission[]>();
@@ -170,6 +181,10 @@ export default function UserDetailClient({
   useEffect(() => {
     setAvailableTrainingRows(availableTrainings);
   }, [availableTrainings]);
+
+  useEffect(() => {
+    setSelectedMergeSourceId(mergeCandidates[0]?.id ?? 0);
+  }, [mergeCandidates]);
 
   const visibleTabs: Array<{ key: TabKey; label: string }> = [
     { key: 'overview', label: 'Overview' },
@@ -990,6 +1005,89 @@ export default function UserDetailClient({
               </div>
             </div>
           )}
+
+          <div className="mb-4">
+            <h3 className="font-semibold mb-3" style={{ color: 'var(--foreground)' }}>Account Merge</h3>
+            <p className="text-xs mb-3" style={{ color: 'var(--muted-foreground)' }}>
+              Merge a duplicate account into this user. Linked providers and profile data are moved, then the source account is deleted.
+            </p>
+            {mergeCandidates.length === 0 ? (
+              <p className="text-sm" style={{ color: 'var(--muted-foreground)' }}>
+                No other users available to merge.
+              </p>
+            ) : (
+              <div className="flex flex-col sm:flex-row gap-2">
+                <select
+                  value={selectedMergeSourceId}
+                  onChange={(event) => setSelectedMergeSourceId(Number(event.target.value))}
+                  className="flex-1 min-w-0 px-3 py-2 rounded border text-sm"
+                  style={{
+                    borderColor: 'var(--border)',
+                    backgroundColor: 'var(--background)',
+                    color: 'var(--foreground)',
+                  }}
+                  disabled={isMergingAccount}
+                >
+                  <option value={0} disabled>Select source account to merge</option>
+                  {mergeCandidates.map((candidate) => (
+                    <option key={candidate.id} value={candidate.id}>
+                      #{candidate.id} {candidate.username || 'Unknown User'}
+                      {candidate.providers.length > 0 ? ` (${candidate.providers.join(', ')})` : ''}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  disabled={!selectedMergeSourceId || isMergingAccount}
+                  onClick={async () => {
+                    if (!selectedMergeSourceId) {
+                      return;
+                    }
+
+                    const sourceUser = mergeCandidates.find((candidate) => candidate.id === selectedMergeSourceId);
+                    const sourceLabel = sourceUser?.username || `User #${selectedMergeSourceId}`;
+                    const confirmed = window.confirm(
+                      `Merge ${sourceLabel} (#${selectedMergeSourceId}) into ${displayUsername} (#${user.id})? This deletes the source account.`
+                    );
+
+                    if (!confirmed) {
+                      return;
+                    }
+
+                    setIsMergingAccount(true);
+                    try {
+                      const response = await fetch('/api/admin/users/merge', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                          sourceUserId: selectedMergeSourceId,
+                          targetUserId: user.id,
+                        }),
+                      });
+
+                      if (!response.ok) {
+                        const data = await response.json().catch(() => ({}));
+                        throw new Error(data.error || 'Failed to merge accounts');
+                      }
+
+                      const data = await response.json();
+                      const movedAccounts = Number(data?.summary?.movedAccounts ?? 0);
+                      showSuccess(`Accounts merged successfully. Linked providers moved: ${movedAccounts}.`);
+                      router.refresh();
+                    } catch (error) {
+                      showError(error instanceof Error ? error.message : 'Failed to merge accounts');
+                    } finally {
+                      setIsMergingAccount(false);
+                    }
+                  }}
+                  className="px-4 py-2 rounded text-sm font-medium disabled:opacity-50"
+                  style={{ backgroundColor: 'var(--primary)', color: 'var(--primary-foreground)' }}
+                >
+                  {isMergingAccount ? 'Merging...' : 'Merge Into This User'}
+                </button>
+              </div>
+            )}
+          </div>
 
           <h3 className="font-semibold mb-3" style={{ color: 'var(--foreground)' }}>Danger Zone</h3>
           <div className="space-y-2">

--- a/app/admin/users/[id]/page.tsx
+++ b/app/admin/users/[id]/page.tsx
@@ -125,6 +125,7 @@ export default async function UserDetailPage({
     allPermissions,
     assignedPermissions,
     ranks,
+    mergeCandidates,
   ] =
     await Promise.all([
       getTotalAttendanceWithLegacy(userId), // Total including legacy data
@@ -153,6 +154,25 @@ export default async function UserDetailPage({
           name: true,
           abbreviation: true,
           orderIndex: true,
+        },
+      }),
+      prisma.user.findMany({
+        where: {
+          id: { not: userId },
+        },
+        orderBy: [
+          { username: 'asc' },
+          { id: 'asc' },
+        ],
+        select: {
+          id: true,
+          username: true,
+          email: true,
+          accounts: {
+            select: {
+              provider: true,
+            },
+          },
         },
       }),
     ]);
@@ -270,6 +290,12 @@ export default async function UserDetailPage({
           user={userData}
           attendance={attendanceData}
           permissions={permissions}
+          mergeCandidates={mergeCandidates.map((candidate) => ({
+            id: candidate.id,
+            username: candidate.username,
+            email: candidate.email,
+            providers: candidate.accounts.map((account) => account.provider),
+          }))}
           availableTrainings={availableTrainings}
           canViewTrainings={canViewTrainings}
           canAssignTrainings={canMarkTrainings}

--- a/app/api/admin/users/merge/route.ts
+++ b/app/api/admin/users/merge/route.ts
@@ -128,6 +128,11 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
 
+    const origin = request.headers.get('origin');
+    if (origin && origin !== request.nextUrl.origin) {
+      return NextResponse.json({ error: 'Invalid origin' }, { status: 403 });
+    }
+
     const body = (await request.json()) as MergeRequestBody;
     const sourceUserId = Number(body?.sourceUserId);
     const targetUserId = Number(body?.targetUserId);

--- a/app/api/admin/users/merge/route.ts
+++ b/app/api/admin/users/merge/route.ts
@@ -1,0 +1,381 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '@/app/api/auth/[...nextauth]/route';
+import { checkPermission } from '@/lib/auth-middleware';
+import { prisma } from '@/lib/prisma';
+import { publishUserProfileEvent } from '@/lib/realtime/user-events';
+
+type MergeRequestBody = {
+  sourceUserId?: number;
+  targetUserId?: number;
+};
+
+type MergeSummary = {
+  movedAccounts: number;
+  discardedAccounts: number;
+  droppedDuplicateSignups: number;
+  droppedDuplicateTrainings: number;
+  droppedDuplicatePermissions: number;
+  droppedDuplicatePromotionProposals: number;
+  droppedDuplicateAttendanceNotes: number;
+  droppedDuplicateMessageRecipients: number;
+  updatedReferenceColumns: number;
+  movedReferenceRows: number;
+  remainingSourceReferences: number;
+};
+
+type UserForeignKeyReference = {
+  tableName: string;
+  columnName: string;
+};
+
+type RemainingReference = {
+  tableName: string;
+  columnName: string;
+  rowCount: bigint;
+};
+
+function quoteIdentifier(identifier: string) {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(identifier)) {
+    throw new Error(`Unsafe identifier: ${identifier}`);
+  }
+
+  return `"${identifier}"`;
+}
+
+async function getUserForeignKeyReferences(tx: Parameters<Parameters<typeof prisma.$transaction>[0]>[0]) {
+  const rows = await tx.$queryRaw<Array<UserForeignKeyReference>>`
+    SELECT
+      tc.table_name AS "tableName",
+      kcu.column_name AS "columnName"
+    FROM information_schema.table_constraints tc
+    JOIN information_schema.key_column_usage kcu
+      ON tc.constraint_name = kcu.constraint_name
+      AND tc.table_schema = kcu.table_schema
+    JOIN information_schema.constraint_column_usage ccu
+      ON tc.constraint_name = ccu.constraint_name
+      AND tc.table_schema = ccu.table_schema
+    WHERE tc.constraint_type = 'FOREIGN KEY'
+      AND tc.table_schema = 'public'
+      AND ccu.table_schema = 'public'
+      AND ccu.table_name = 'User'
+      AND ccu.column_name = 'id'
+  `;
+
+  return rows.filter((row) => row.tableName !== 'User');
+}
+
+async function moveAllUserReferences(
+  tx: Parameters<Parameters<typeof prisma.$transaction>[0]>[0],
+  references: UserForeignKeyReference[],
+  sourceUserId: number,
+  targetUserId: number
+) {
+  let movedReferenceRows = 0;
+
+  for (const reference of references) {
+    const tableName = quoteIdentifier(reference.tableName);
+    const columnName = quoteIdentifier(reference.columnName);
+    const updatedRows = await tx.$executeRawUnsafe(
+      `UPDATE ${tableName} SET ${columnName} = $1 WHERE ${columnName} = $2`,
+      targetUserId,
+      sourceUserId
+    );
+    movedReferenceRows += Number(updatedRows);
+  }
+
+  return movedReferenceRows;
+}
+
+async function countRemainingSourceReferences(
+  tx: Parameters<Parameters<typeof prisma.$transaction>[0]>[0],
+  references: UserForeignKeyReference[],
+  sourceUserId: number
+) {
+  const remaining: RemainingReference[] = [];
+
+  for (const reference of references) {
+    const tableName = quoteIdentifier(reference.tableName);
+    const columnName = quoteIdentifier(reference.columnName);
+    const rows = await tx.$queryRawUnsafe<Array<{ rowCount: bigint }>>(
+      `SELECT COUNT(*)::bigint AS "rowCount" FROM ${tableName} WHERE ${columnName} = $1`,
+      sourceUserId
+    );
+
+    const rowCount = rows[0]?.rowCount ?? BigInt(0);
+    if (rowCount > BigInt(0)) {
+      remaining.push({
+        tableName: reference.tableName,
+        columnName: reference.columnName,
+        rowCount,
+      });
+    }
+  }
+
+  return remaining;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const hasPermission = await checkPermission(session.user.id, 'user:manage');
+    if (!hasPermission) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+
+    const body = (await request.json()) as MergeRequestBody;
+    const sourceUserId = Number(body?.sourceUserId);
+    const targetUserId = Number(body?.targetUserId);
+
+    if (!Number.isInteger(sourceUserId) || sourceUserId <= 0) {
+      return NextResponse.json({ error: 'Invalid source user ID' }, { status: 400 });
+    }
+
+    if (!Number.isInteger(targetUserId) || targetUserId <= 0) {
+      return NextResponse.json({ error: 'Invalid target user ID' }, { status: 400 });
+    }
+
+    if (sourceUserId === targetUserId) {
+      return NextResponse.json({ error: 'Source and target must be different users' }, { status: 400 });
+    }
+
+    if (sourceUserId === session.user.id) {
+      return NextResponse.json({ error: 'Cannot merge and delete your own account' }, { status: 400 });
+    }
+
+    const [sourceUser, targetUser] = await Promise.all([
+      prisma.user.findUnique({ where: { id: sourceUserId }, select: { id: true } }),
+      prisma.user.findUnique({ where: { id: targetUserId }, select: { id: true } }),
+    ]);
+
+    if (!sourceUser || !targetUser) {
+      return NextResponse.json({ error: 'Source or target user not found' }, { status: 404 });
+    }
+
+    const summary = await prisma.$transaction(async (tx) => {
+      const result: MergeSummary = {
+        movedAccounts: 0,
+        discardedAccounts: 0,
+        droppedDuplicateSignups: 0,
+        droppedDuplicateTrainings: 0,
+        droppedDuplicatePermissions: 0,
+        droppedDuplicatePromotionProposals: 0,
+        droppedDuplicateAttendanceNotes: 0,
+        droppedDuplicateMessageRecipients: 0,
+        updatedReferenceColumns: 0,
+        movedReferenceRows: 0,
+        remainingSourceReferences: 0,
+      };
+
+      const userForeignKeyReferences = await getUserForeignKeyReferences(tx);
+      result.updatedReferenceColumns = userForeignKeyReferences.length;
+
+      const [sourceAccounts, targetAccounts] = await Promise.all([
+        tx.authAccount.findMany({ where: { userId: sourceUserId } }),
+        tx.authAccount.findMany({ where: { userId: targetUserId } }),
+      ]);
+
+      const targetProviders = new Set(targetAccounts.map((account) => account.provider));
+      for (const account of sourceAccounts) {
+        if (targetProviders.has(account.provider)) {
+          await tx.authAccount.delete({ where: { id: account.id } });
+          result.discardedAccounts += 1;
+          continue;
+        }
+
+        await tx.authAccount.update({
+          where: { id: account.id },
+          data: { userId: targetUserId },
+        });
+        targetProviders.add(account.provider);
+        result.movedAccounts += 1;
+      }
+
+      const [
+        targetSignups,
+        targetTrainings,
+        targetPermissions,
+        targetPromotionProposals,
+        targetAttendanceNotes,
+        targetMessageRecipients,
+      ] = await Promise.all([
+        tx.signup.findMany({ where: { userId: targetUserId }, select: { slotId: true } }),
+        tx.userTraining.findMany({ where: { userId: targetUserId }, select: { trainingId: true } }),
+        tx.userPermission.findMany({ where: { userId: targetUserId }, select: { permissionId: true } }),
+        tx.promotionProposal.findMany({ where: { userId: targetUserId }, select: { nextRankId: true } }),
+        tx.orbatAttendanceNote.findMany({ where: { userId: targetUserId }, select: { orbatId: true } }),
+        tx.messageRecipient.findMany({ where: { userId: targetUserId }, select: { messageId: true } }),
+      ]);
+
+      if (targetSignups.length > 0) {
+        const duplicateRows = await tx.signup.findMany({
+          where: {
+            userId: sourceUserId,
+            slotId: { in: targetSignups.map((row) => row.slotId) },
+          },
+          select: { id: true },
+        });
+
+        if (duplicateRows.length > 0) {
+          await tx.signup.deleteMany({ where: { id: { in: duplicateRows.map((row) => row.id) } } });
+          result.droppedDuplicateSignups = duplicateRows.length;
+        }
+      }
+
+      if (targetTrainings.length > 0) {
+        const duplicateRows = await tx.userTraining.findMany({
+          where: {
+            userId: sourceUserId,
+            trainingId: { in: targetTrainings.map((row) => row.trainingId) },
+          },
+          select: { id: true },
+        });
+
+        if (duplicateRows.length > 0) {
+          await tx.userTraining.deleteMany({ where: { id: { in: duplicateRows.map((row) => row.id) } } });
+          result.droppedDuplicateTrainings = duplicateRows.length;
+        }
+      }
+
+      if (targetPermissions.length > 0) {
+        const duplicateRows = await tx.userPermission.findMany({
+          where: {
+            userId: sourceUserId,
+            permissionId: { in: targetPermissions.map((row) => row.permissionId) },
+          },
+          select: { id: true },
+        });
+
+        if (duplicateRows.length > 0) {
+          await tx.userPermission.deleteMany({ where: { id: { in: duplicateRows.map((row) => row.id) } } });
+          result.droppedDuplicatePermissions = duplicateRows.length;
+        }
+      }
+
+      if (targetPromotionProposals.length > 0) {
+        const duplicateRows = await tx.promotionProposal.findMany({
+          where: {
+            userId: sourceUserId,
+            nextRankId: { in: targetPromotionProposals.map((row) => row.nextRankId) },
+          },
+          select: { id: true },
+        });
+
+        if (duplicateRows.length > 0) {
+          await tx.promotionProposal.deleteMany({ where: { id: { in: duplicateRows.map((row) => row.id) } } });
+          result.droppedDuplicatePromotionProposals = duplicateRows.length;
+        }
+      }
+
+      if (targetAttendanceNotes.length > 0) {
+        const duplicateRows = await tx.orbatAttendanceNote.findMany({
+          where: {
+            userId: sourceUserId,
+            orbatId: { in: targetAttendanceNotes.map((row) => row.orbatId) },
+          },
+          select: { id: true },
+        });
+
+        if (duplicateRows.length > 0) {
+          await tx.orbatAttendanceNote.deleteMany({ where: { id: { in: duplicateRows.map((row) => row.id) } } });
+          result.droppedDuplicateAttendanceNotes = duplicateRows.length;
+        }
+      }
+
+      if (targetMessageRecipients.length > 0) {
+        const duplicateRows = await tx.messageRecipient.findMany({
+          where: {
+            userId: sourceUserId,
+            messageId: { in: targetMessageRecipients.map((row) => row.messageId) },
+          },
+          select: { id: true },
+        });
+
+        if (duplicateRows.length > 0) {
+          await tx.messageRecipient.deleteMany({ where: { id: { in: duplicateRows.map((row) => row.id) } } });
+          result.droppedDuplicateMessageRecipients = duplicateRows.length;
+        }
+      }
+
+      const [sourceRank, targetRank] = await Promise.all([
+        tx.userRank.findUnique({ where: { userId: sourceUserId } }),
+        tx.userRank.findUnique({ where: { userId: targetUserId } }),
+      ]);
+
+      if (sourceRank && !targetRank) {
+        await tx.userRank.update({
+          where: { id: sourceRank.id },
+          data: { userId: targetUserId },
+        });
+      }
+
+      if (sourceRank && targetRank) {
+        await tx.userRank.update({
+          where: { id: targetRank.id },
+          data: {
+            currentRankId: targetRank.currentRankId ?? sourceRank.currentRankId,
+            attendanceSinceLastRank: Math.max(targetRank.attendanceSinceLastRank, sourceRank.attendanceSinceLastRank),
+            retired: targetRank.retired || sourceRank.retired,
+            interviewDone: targetRank.interviewDone || sourceRank.interviewDone,
+            lastRankedUpAt:
+              targetRank.lastRankedUpAt.getTime() <= sourceRank.lastRankedUpAt.getTime()
+                ? targetRank.lastRankedUpAt
+                : sourceRank.lastRankedUpAt,
+          },
+        });
+
+        await tx.userRank.delete({ where: { id: sourceRank.id } });
+      }
+
+      result.movedReferenceRows = await moveAllUserReferences(
+        tx,
+        userForeignKeyReferences,
+        sourceUserId,
+        targetUserId
+      );
+
+      const remainingReferences = await countRemainingSourceReferences(tx, userForeignKeyReferences, sourceUserId);
+      result.remainingSourceReferences = remainingReferences.reduce(
+        (total, reference) => total + Number(reference.rowCount),
+        0
+      );
+
+      if (remainingReferences.length > 0) {
+        const details = remainingReferences
+          .map((reference) => `${reference.tableName}.${reference.columnName}=${reference.rowCount.toString()}`)
+          .join(', ');
+        throw new Error(`Unable to migrate all user references: ${details}`);
+      }
+
+      await tx.user.delete({ where: { id: sourceUserId } });
+
+      return result;
+    });
+
+    const eventPayload = {
+      action: 'account.merged',
+      actorUserId: session.user.id,
+      sourceUserId,
+      targetUserId,
+      summary,
+    };
+
+    publishUserProfileEvent(targetUserId, eventPayload);
+    publishUserProfileEvent(sourceUserId, eventPayload);
+
+    return NextResponse.json({
+      success: true,
+      mergedIntoUserId: targetUserId,
+      removedUserId: sourceUserId,
+      summary,
+    });
+  } catch (error) {
+    console.error('Error merging users:', error);
+    return NextResponse.json({ error: 'Failed to merge users' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
This pull request introduces a complete user account merge feature in the admin user detail page. It enables admins to merge duplicate user accounts, consolidating their linked providers and profile data, while handling potential data conflicts and ensuring data integrity across related tables. The implementation includes both backend logic and frontend UI for selecting and merging accounts.

The most important changes are:

**Backend: Account Merge API**
* Added a new API endpoint at `/api/admin/users/merge` to handle merging one user account into another. This endpoint moves all related data, resolves duplicates for signups, trainings, permissions, and other relations, and deletes the source account, with safeguards against unsafe or incomplete merges.

**Frontend: User Detail Page UI**
* Added a new "Account Merge" section to the `UserDetailClient` component, allowing admins to select a merge candidate and trigger the merge process with confirmation and feedback. ([app/admin/users/[id]/UserDetailClient.tsxR1009-R1091](diffhunk://#diff-059954c9c4872aa5def5e7a0b3ba7ea5a4fc17e289d46e6868f72b18e929a9c5R1009-R1091))
* Managed new state variables in `UserDetailClient` for merge candidate selection and merge operation progress. ([app/admin/users/[id]/UserDetailClient.tsxR148-R149](diffhunk://#diff-059954c9c4872aa5def5e7a0b3ba7ea5a4fc17e289d46e6868f72b18e929a9c5R148-R149), [app/admin/users/[id]/UserDetailClient.tsxR185-R188](diffhunk://#diff-059954c9c4872aa5def5e7a0b3ba7ea5a4fc17e289d46e6868f72b18e929a9c5R185-R188))

**Data Fetching and Propagation**
* Updated the user detail page server logic to fetch merge candidates (all other users) and pass them to the client, including their linked providers for display. ([app/admin/users/[id]/page.tsxR159-R177](diffhunk://#diff-20bfec82d13691367f84f79ebe61317a599a3d8421221442477defa9e479912fR159-R177), [app/admin/users/[id]/page.tsxR293-R298](diffhunk://#diff-20bfec82d13691367f84f79ebe61317a599a3d8421221442477defa9e479912fR293-R298), [app/admin/users/[id]/page.tsxR128](diffhunk://#diff-20bfec82d13691367f84f79ebe61317a599a3d8421221442477defa9e479912fR128))
* Extended the prop types and function signatures to support the new `mergeCandidates` data. ([app/admin/users/[id]/UserDetailClient.tsxR83-R94](diffhunk://#diff-059954c9c4872aa5def5e7a0b3ba7ea5a4fc17e289d46e6868f72b18e929a9c5R83-R94), [app/admin/users/[id]/UserDetailClient.tsxR113](diffhunk://#diff-059954c9c4872aa5def5e7a0b3ba7ea5a4fc17e289d46e6868f72b18e929a9c5R113))

These changes together provide a secure and user-friendly way for admins to merge duplicate accounts directly from the user detail page.