### PR TITLE
feat: implement CSRF protection for user account merging

### DIFF
--- a/app/admin/users/[id]/UserDetailClient.tsx
+++ b/app/admin/users/[id]/UserDetailClient.tsx
@@ -1056,9 +1056,29 @@ export default function UserDetailClient({
 
                     setIsMergingAccount(true);
                     try {
+                      const csrfResponse = await fetch('/api/auth/csrf', {
+                        method: 'GET',
+                        cache: 'no-store',
+                        credentials: 'same-origin',
+                      });
+
+                      if (!csrfResponse.ok) {
+                        throw new Error('Failed to fetch CSRF token');
+                      }
+
+                      const csrfData = await csrfResponse.json().catch(() => ({}));
+                      const csrfToken = typeof csrfData?.csrfToken === 'string' ? csrfData.csrfToken : '';
+                      if (!csrfToken) {
+                        throw new Error('Missing CSRF token');
+                      }
+
                       const response = await fetch('/api/admin/users/merge', {
                         method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
+                        headers: {
+                          'Content-Type': 'application/json',
+                          'x-csrf-token': csrfToken,
+                        },
+                        credentials: 'same-origin',
                         body: JSON.stringify({
                           sourceUserId: selectedMergeSourceId,
                           targetUserId: user.id,

--- a/app/api/admin/users/merge/route.ts
+++ b/app/api/admin/users/merge/route.ts
@@ -35,6 +35,31 @@ type RemainingReference = {
   rowCount: bigint;
 };
 
+function getCsrfCookieToken(request: NextRequest) {
+  const cookieValue =
+    request.cookies.get('__Host-next-auth.csrf-token')?.value ??
+    request.cookies.get('next-auth.csrf-token')?.value ??
+    null;
+
+  if (!cookieValue) {
+    return null;
+  }
+
+  const [token] = cookieValue.split('|');
+  return token || null;
+}
+
+function hasValidCsrfToken(request: NextRequest) {
+  const headerToken = request.headers.get('x-csrf-token')?.trim() ?? '';
+  const cookieToken = getCsrfCookieToken(request);
+
+  if (!headerToken || !cookieToken) {
+    return false;
+  }
+
+  return headerToken === cookieToken;
+}
+
 function quoteIdentifier(identifier: string) {
   if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(identifier)) {
     throw new Error(`Unsafe identifier: ${identifier}`);
@@ -128,9 +153,8 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
 
-    const origin = request.headers.get('origin');
-    if (origin && origin !== request.nextUrl.origin) {
-      return NextResponse.json({ error: 'Invalid origin' }, { status: 403 });
+    if (!hasValidCsrfToken(request)) {
+      return NextResponse.json({ error: 'Invalid CSRF token' }, { status: 403 });
     }
 
     const body = (await request.json()) as MergeRequestBody;

--- a/app/api/admin/users/merge/route.ts
+++ b/app/api/admin/users/merge/route.ts
@@ -51,13 +51,22 @@ function getCsrfCookieToken(request: NextRequest) {
 
 function hasValidCsrfToken(request: NextRequest) {
   const headerToken = request.headers.get('x-csrf-token')?.trim() ?? '';
-  const cookieToken = getCsrfCookieToken(request);
+  const cookieToken = getCsrfCookieToken(request)?.trim() ?? '';
 
   if (!headerToken || !cookieToken) {
     return false;
   }
 
-  return headerToken === cookieToken;
+  if (headerToken.length !== cookieToken.length) {
+    return false;
+  }
+
+  let diff = 0;
+  for (let i = 0; i < headerToken.length; i += 1) {
+    diff |= headerToken.charCodeAt(i) ^ cookieToken.charCodeAt(i);
+  }
+
+  return diff === 0;
 }
 
 function quoteIdentifier(identifier: string) {


### PR DESCRIPTION
This pull request adds CSRF protection to the user account merge functionality in the admin panel. The main changes include fetching a CSRF token on the client, sending it with the merge request, and validating it on the server before processing the request.

**CSRF Protection Implementation:**

* `UserDetailClient.tsx`: Fetches the CSRF token from `/api/auth/csrf` before merging accounts, includes the token in the `x-csrf-token` header of the merge request, and ensures credentials are sent with the request. ([app/admin/users/[id]/UserDetailClient.tsxR1059-R1081](diffhunk://#diff-059954c9c4872aa5def5e7a0b3ba7ea5a4fc17e289d46e6868f72b18e929a9c5R1059-R1081))
* [`merge/route.ts`](diffhunk://#diff-6332d050953fbbd04f24e29c4c43f09fa0657ae2865947d27064ef4ccabb6130R38-R62): Adds helper functions `getCsrfCookieToken` and `hasValidCsrfToken` to extract and validate the CSRF token from cookies and headers.
* [`merge/route.ts`](diffhunk://#diff-6332d050953fbbd04f24e29c4c43f09fa0657ae2865947d27064ef4ccabb6130L131-R157): Updates the `POST` handler to check for a valid CSRF token and reject requests with an invalid or missing token, replacing the previous origin check.