### PR TITLE
Update attendance status calculation to ignore minor lateness

### DIFF
--- a/lib/attendance.ts
+++ b/lib/attendance.ts
@@ -27,9 +27,12 @@ export function calculateAttendanceStatus(
     return 'no_show';
   }
 
-  // If checked in, determine partial vs late vs gone_early vs present.
-  // Missing-time values are capped at 60 elsewhere; status remains side-specific
-  // unless both late and gone_early are true.
+  // Under 60 total minutes missed → present (minor lateness/early departure ignored)
+  if (totalMinutesMissed < 60) {
+    return 'present';
+  }
+
+  // 60+ minutes missed: determine which side(s) contributed
   if (minutesLate > 0 && minutesGoneEarly > 0) {
     return 'partial';
   }
@@ -38,11 +41,7 @@ export function calculateAttendanceStatus(
     return 'late';
   }
 
-  if (minutesGoneEarly > 0) {
-    return 'gone_early';
-  }
-
-  return 'present';
+  return 'gone_early';
 }
 
 /**


### PR DESCRIPTION
This pull request updates the logic for determining attendance status in the `calculateAttendanceStatus` function in `lib/attendance.ts`. The main change is to simplify and clarify how the function classifies a participant as "present" versus "partial", "late", or "gone_early" based on the total minutes missed.

**Attendance status calculation improvements:**

* Now, if the participant misses less than 60 total minutes (regardless of whether it was due to being late or leaving early), they are classified as `'present'`, ignoring minor lateness or early departure.
* If 60 or more minutes are missed, the function determines if the absence was due to lateness, early departure, or both, and assigns `'partial'`, `'late'`, or `'gone_early'` accordingly. [[1]](diffhunk://#diff-ceb1ee1ff61572fc65b389813750f3ff07832b2850063ab71271fb05ed8f69aaL30-R35) [[2]](diffhunk://#diff-ceb1ee1ff61572fc65b389813750f3ff07832b2850063ab71271fb05ed8f69aaL41-L47)

These changes make the attendance status logic more intuitive and ensure minor absences do not affect the overall status.…d early departures