### PR TITLE
Refactor attendance status determination with shared logic

### DIFF
--- a/app/api/bot/attendance/compile/route.ts
+++ b/app/api/bot/attendance/compile/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
 import { validateBotTokenLegacy } from '@/lib/bot-token-validation';
 import { buildAttendanceNoteFlags } from '@/lib/attendance-note-flags';
+import { calculateAttendanceStatus } from '@/lib/attendance';
 
 function validateBotToken(request: NextRequest): Promise<boolean> {
   return validateBotTokenLegacy(request);
@@ -208,13 +209,10 @@ export async function POST(request: NextRequest) {
 
       totalMinutesMissed = minutesLate + minutesGoneEarly;
 
-      // Determine status
-      const status: 'present' | 'absent' | 'partial' | 'late' | 'gone_early' | 'no_show' = 
-        joins.length === 0 ? 'no_show' :
-        minutesLate > 0 && minutesGoneEarly > 0 ? 'partial' :
-        minutesLate > 0 ? 'late' :
-        minutesGoneEarly > 0 ? 'gone_early' :
-        totalMinutesPresent > 0 ? 'present' : 'absent';
+      // Determine status using shared logic (60-minute threshold)
+      const status = joins.length === 0
+        ? 'no_show'
+        : calculateAttendanceStatus(true, minutesLate, minutesGoneEarly, totalMinutesMissed);
 
       const noteFlags = buildAttendanceNoteFlags(noteByUserId.get(userIdNum) ?? null);
 
@@ -227,7 +225,7 @@ export async function POST(request: NextRequest) {
           signupId: signup.id,
           orbatId: orbat.id,
           userId: userIdNum,
-          status: status as 'present' | 'absent' | 'partial' | 'late' | 'gone_early' | 'no_show',
+          status,
           totalMinutesPresent,
           minutesLate,
           minutesGoneEarly,
@@ -235,7 +233,7 @@ export async function POST(request: NextRequest) {
           ...noteFlags,
         },
         update: {
-          status: status as 'present' | 'absent' | 'partial' | 'late' | 'gone_early' | 'no_show',
+          status,
           totalMinutesPresent,
           minutesLate,
           minutesGoneEarly,


### PR DESCRIPTION
This pull request refactors how attendance status is determined in the `app/api/bot/attendance/compile/route.ts` API route. The main improvement is the use of a shared utility function, `calculateAttendanceStatus`, to standardize status calculation logic across the codebase.

**Refactoring and logic standardization:**

* Replaced the inline attendance status calculation logic in the POST handler with a call to the shared `calculateAttendanceStatus` function, ensuring consistent status determination and easier future maintenance.
* Imported the `calculateAttendanceStatus` utility from `@/lib/attendance` to enable the above change.

**Type handling improvements:**

* Removed redundant type assertions for the `status` field when creating or updating attendance records, as the new function already returns the correct type.